### PR TITLE
Add account and notes fields to transaction form

### DIFF
--- a/lib/features/transactions/models/transaction_model.dart
+++ b/lib/features/transactions/models/transaction_model.dart
@@ -9,6 +9,8 @@ class Transaction {
   final String categoryName;
   final String categoryIcon;
   final Color categoryColor;
+  final String? accountId;
+  final String? notes;
 
   Transaction({
     required this.id,
@@ -19,6 +21,8 @@ class Transaction {
     required this.categoryName,
     required this.categoryIcon,
     required this.categoryColor,
+    this.accountId,
+    this.notes,
   });
 
   factory Transaction.fromJson(Map<String, dynamic> json) {
@@ -44,6 +48,8 @@ class Transaction {
       categoryName: (json['categories'] as Map<String, dynamic>?)?['name'] as String? ?? 'Sin Categoría',
       categoryIcon: (json['categories'] as Map<String, dynamic>?)?['icon'] as String? ?? 'fas fa-question-circle',
       categoryColor: parseColor((json['categories'] as Map<String, dynamic>?)?['color'] as String?),
+      accountId: json['account_id'] as String?,
+      notes: json['notes'] as String?,
     );
   }
 }


### PR DESCRIPTION
## Summary
- add controllers and state for notes and accounts
- fetch accounts from Supabase
- include account and notes in transaction upsert
- add account dropdown and notes field to UI
- update Transaction model for account and notes data

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688bda8c51dc8325b39fd92f114a6b7c