### PR TITLE
Move profile advanced settings to gear icon

### DIFF
--- a/lib/features/profile/screens/profile_screen.dart
+++ b/lib/features/profile/screens/profile_screen.dart
@@ -213,10 +213,13 @@ class _ProfileScreenState extends State<ProfileScreen> {
                 ),
               ]
             : [
-                // Botón para ir a la pantalla de Ajustes
+                // Botón para ir a la pantalla de Configuración avanzada
                 IconButton(
                   icon: const Icon(Icons.settings_outlined),
-                  onPressed: () { /* TODO: Navegar a Ajustes */ },
+                  onPressed: () {
+                    Navigator.of(context).pushNamed('/settings');
+                  },
+                  tooltip: 'Configuración',
                 ),
                 // Botón para cerrar sesión
                 IconButton(
@@ -338,18 +341,10 @@ class _ProfileScreenState extends State<ProfileScreen> {
                        },
                      ),
                    ],
-                 ),
-                 ListTile(
-                  leading: const Icon(Icons.settings_outlined),
-                  title: const Text('Configuración Avanzada'),
-                  trailing: const Icon(Icons.arrow_forward_ios, size: 16),
-                    onTap: () {
-                  Navigator.of(context).pushNamed('/settings');
-                  },
-                ),
-              ],
-            ),
-            
+                  ),
+                ],
+              ),
+
     );
   }
 


### PR DESCRIPTION
## Summary
- Open advanced settings from gear icon in profile app bar
- Remove redundant advanced settings list item at end of profile

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aaededf7548325b310585b061c904e