### PR TITLE
feat: handle budget copy conflicts

### DIFF
--- a/lib/features/budgets/services/budget_service.dart
+++ b/lib/features/budgets/services/budget_service.dart
@@ -113,26 +113,103 @@ class BudgetService {
     }
   }
 
-  Future<void> copyBudgetsFromLastMonth() async {
+  Future<bool> hasConflictingBudgetsFromLastMonth() async {
     final userId = _supabase.auth.currentUser!.id;
     final now = DateTime.now();
     final firstDayCurrentMonth = DateTime(now.year, now.month, 1);
     final firstDayLastMonth = DateTime(now.year, now.month - 1, 1);
     final lastDayLastMonth = firstDayCurrentMonth.subtract(const Duration(days: 1));
-    final lastMonthBudgets = await _supabase.from('budgets').select('category_id, amount, period').eq('user_id', userId).gte('start_date', firstDayLastMonth.toIso8601String()).lte('start_date', lastDayLastMonth.toIso8601String());
+
+    final lastMonthBudgets = await _supabase
+        .from('budgets')
+        .select('category_id')
+        .eq('user_id', userId)
+        .gte('start_date', firstDayLastMonth.toIso8601String())
+        .lte('start_date', lastDayLastMonth.toIso8601String());
+    if (lastMonthBudgets.isEmpty) return false;
+
+    final currentBudgets = await _supabase
+        .from('budgets')
+        .select('category_id')
+        .eq('user_id', userId)
+        .gte('start_date', firstDayCurrentMonth.toIso8601String());
+
+    final lastMonthCategoryIds =
+        lastMonthBudgets.map((b) => b['category_id'] as String).toSet();
+    final currentCategoryIds =
+        currentBudgets.map((b) => b['category_id'] as String).toSet();
+
+    return lastMonthCategoryIds.intersection(currentCategoryIds).isNotEmpty;
+  }
+
+  Future<void> copyBudgetsFromLastMonth({bool overwriteExisting = false}) async {
+    final userId = _supabase.auth.currentUser!.id;
+    final now = DateTime.now();
+    final firstDayCurrentMonth = DateTime(now.year, now.month, 1);
+    final firstDayLastMonth = DateTime(now.year, now.month - 1, 1);
+    final lastDayLastMonth = firstDayCurrentMonth.subtract(const Duration(days: 1));
+
+    final lastMonthBudgets = await _supabase
+        .from('budgets')
+        .select('category_id, amount, period')
+        .eq('user_id', userId)
+        .gte('start_date', firstDayLastMonth.toIso8601String())
+        .lte('start_date', lastDayLastMonth.toIso8601String());
     if (lastMonthBudgets.isEmpty) {
       throw Exception('No se encontraron presupuestos en el mes anterior para copiar.');
     }
-    final newBudgets = lastMonthBudgets.map((budget) {
-      return {
+
+    final currentBudgets = await _supabase
+        .from('budgets')
+        .select('id, category_id')
+        .eq('user_id', userId)
+        .gte('start_date', firstDayCurrentMonth.toIso8601String());
+
+    final currentMap = {for (var b in currentBudgets) b['category_id']: b['id']};
+
+    final List<Map<String, dynamic>> newBudgets = [];
+    final List<Map<String, dynamic>> existingBudgets = [];
+
+    for (var budget in lastMonthBudgets) {
+      final categoryId = budget['category_id'] as String;
+      final data = {
         'user_id': userId,
-        'category_id': budget['category_id'],
+        'category_id': categoryId,
         'amount': budget['amount'],
         'start_date': firstDayCurrentMonth.toIso8601String(),
         'period': budget['period'],
       };
-    }).toList();
-    await _supabase.from('budgets').insert(newBudgets);
+      if (currentMap.containsKey(categoryId)) {
+        data['id'] = currentMap[categoryId];
+        existingBudgets.add(data);
+      } else {
+        newBudgets.add(data);
+      }
+    }
+
+    if (newBudgets.isNotEmpty) {
+      await _supabase.from('budgets').insert(newBudgets);
+    }
+    if (overwriteExisting && existingBudgets.isNotEmpty) {
+      await _supabase.from('budgets').upsert(existingBudgets);
+    }
+  }
+
+  Future<double?> getCategorySpendingSuggestion(String categoryId) async {
+    final userId = _supabase.auth.currentUser!.id;
+    final response = await _supabase.rpc(
+      'get_category_spending_suggestion',
+      params: {
+        'p_user_id': userId,
+        'p_category_id': categoryId,
+      },
+    );
+    if (response == null) return null;
+    if (response is num) return (response as num).toDouble();
+    if (response is Map && response['suggested_amount'] != null) {
+      return (response['suggested_amount'] as num).toDouble();
+    }
+    return null;
   }
 
   Future<void> updateBudgetRollover(bool isEnabled) async {


### PR DESCRIPTION
## Summary
- detect when budgets from last month already exist in the current period
- prompt user to overwrite or add only new budgets before copying
- suggest budget amounts based on past three months spending when selecting a category

## Testing
- `flutter analyze` *(command not found)*
- `dart analyze` *(command not found)*
- `flutter test` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5a978c7308325a0b08ec1b4f71a1f