### PR TITLE
Add budget deletion and previous month budget indicators

### DIFF
--- a/lib/features/budgets/models/budget_model.dart
+++ b/lib/features/budgets/models/budget_model.dart
@@ -12,6 +12,8 @@ class Budget {
   final double spentAmount; // Cuánto se ha gastado
   final double progress; // 0.0 a 1.0
   final double remainingAmount; // Cuánto queda
+  final double lastMonthSpent; // Gastado en el mes anterior
+  final double lastMonthAmount; // Presupuesto del mes anterior
 
   Budget({
     required this.id,
@@ -23,6 +25,8 @@ class Budget {
     this.spentAmount = 0.0,
     this.progress = 0.0,
     this.remainingAmount = 0.0,
+    this.lastMonthSpent = 0.0,
+    this.lastMonthAmount = 0.0,
   });
 }
 

--- a/lib/features/budgets/screens/budget_screen.dart
+++ b/lib/features/budgets/screens/budget_screen.dart
@@ -54,6 +54,18 @@ class _BudgetScreenState extends State<BudgetScreen> {
     }
   }
 
+  Future<void> _deleteBudget(String id) async {
+    await _service.deleteBudget(id);
+    if (mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+            content: Text('Presupuesto eliminado'),
+            backgroundColor: Colors.redAccent),
+      );
+    }
+    _loadData();
+  }
+
   Future<void> _onCopyFromLastMonth() async {
     try {
       bool overwrite = false;
@@ -180,9 +192,10 @@ class _BudgetScreenState extends State<BudgetScreen> {
                           itemCount: budgets.length,
                           itemBuilder: (context, index) {
                             final budget = budgets[index];
-                            return GestureDetector(
+                            return BudgetCard(
+                              budget: budget,
                               onTap: () => _openBudgetDialog(budget: budget),
-                              child: BudgetCard(budget: budget),
+                              onDelete: () => _deleteBudget(budget.id),
                             );
                           },
                         ),

--- a/lib/features/budgets/widgets/budget_card.dart
+++ b/lib/features/budgets/widgets/budget_card.dart
@@ -6,47 +6,108 @@ import '../models/budget_model.dart';
 
 class BudgetCard extends StatelessWidget {
   final Budget budget;
+  final VoidCallback? onTap;
+  final VoidCallback? onDelete;
 
-  const BudgetCard({super.key, required this.budget});
+  const BudgetCard({
+    super.key,
+    required this.budget,
+    this.onTap,
+    this.onDelete,
+  });
 
   @override
   Widget build(BuildContext context) {
     final formatter = NumberFormat.currency(locale: 'es_ES', symbol: '€');
-    final progressColor = budget.progress > 0.85 ? Colors.redAccent : (budget.progress > 0.6 ? Colors.orangeAccent : Colors.green);
+    final progressColor = budget.remainingAmount < 0
+        ? Colors.redAccent
+        : (budget.progress > 0.85
+            ? Colors.redAccent
+            : (budget.progress > 0.6
+                ? Colors.orangeAccent
+                : Colors.green));
+
+    IconData statusIcon;
+    Color statusColor;
+    if (budget.remainingAmount < 0) {
+      statusIcon = Icons.error;
+      statusColor = Colors.redAccent;
+    } else if (budget.progress > 0.85) {
+      statusIcon = Icons.warning;
+      statusColor = Colors.orangeAccent;
+    } else {
+      statusIcon = Icons.check_circle;
+      statusColor = Colors.green;
+    }
 
     return Card(
       margin: const EdgeInsets.symmetric(vertical: 8.0),
-      child: Padding(
-        padding: const EdgeInsets.all(16.0),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text(budget.categoryName, style: Theme.of(context).textTheme.titleLarge),
-            const SizedBox(height: 12),
-            Row(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              children: [
-                Text('Gastado: ${formatter.format(budget.spentAmount)}'),
-                Text('Límite: ${formatter.format(budget.amount)}', style: const TextStyle(fontWeight: FontWeight.bold)),
-              ],
-            ),
-            const SizedBox(height: 8),
-            LinearProgressIndicator(
-              value: budget.progress,
-              minHeight: 10,
-              borderRadius: BorderRadius.circular(5),
-              backgroundColor: Colors.grey.shade300,
-              valueColor: AlwaysStoppedAnimation<Color>(progressColor),
-            ),
-            const SizedBox(height: 8),
-            Align(
-              alignment: Alignment.centerRight,
-              child: Text(
-                'Quedan ${formatter.format(budget.remainingAmount)}',
-                style: TextStyle(fontWeight: FontWeight.bold, color: budget.remainingAmount < 0 ? Colors.red : Colors.black87),
+      child: InkWell(
+        onTap: onTap,
+        child: Padding(
+          padding: const EdgeInsets.all(16.0),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  Icon(statusIcon, color: statusColor),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: Text(budget.categoryName,
+                        style: Theme.of(context).textTheme.titleLarge),
+                  ),
+                  PopupMenuButton<String>(
+                    onSelected: (value) {
+                      if (value == 'delete' && onDelete != null) {
+                        onDelete!();
+                      }
+                    },
+                    itemBuilder: (context) => [
+                      const PopupMenuItem<String>(
+                        value: 'delete',
+                        child: Text('Eliminar'),
+                      ),
+                    ],
+                  ),
+                ],
               ),
-            ),
-          ],
+              const SizedBox(height: 12),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  Text('Gastado: ${formatter.format(budget.spentAmount)}'),
+                  Text('Límite: ${formatter.format(budget.amount)}',
+                      style: const TextStyle(fontWeight: FontWeight.bold)),
+                ],
+              ),
+              const SizedBox(height: 4),
+              Text(
+                'Mes anterior: ${formatter.format(budget.lastMonthSpent)} de ${formatter.format(budget.lastMonthAmount)}',
+                style: Theme.of(context).textTheme.bodySmall,
+              ),
+              const SizedBox(height: 8),
+              LinearProgressIndicator(
+                value: budget.progress,
+                minHeight: 10,
+                borderRadius: BorderRadius.circular(5),
+                backgroundColor: Colors.grey.shade300,
+                valueColor: AlwaysStoppedAnimation<Color>(progressColor),
+              ),
+              const SizedBox(height: 8),
+              Align(
+                alignment: Alignment.centerRight,
+                child: Text(
+                  'Quedan ${formatter.format(budget.remainingAmount)}',
+                  style: TextStyle(
+                      fontWeight: FontWeight.bold,
+                      color: budget.remainingAmount < 0
+                          ? Colors.red
+                          : Colors.black87),
+                ),
+              ),
+            ],
+          ),
         ),
       ),
     );


### PR DESCRIPTION
## Summary
- show status icons and previous month info in budget cards
- allow budgets to be deleted and refresh list
- compute and expose previous month amounts in service and model

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6b41250f48325b3c828d22606ae06