### PR TITLE
feat(budgets): add rollover calculations to budgets

### DIFF
--- a/lib/features/budgets/models/budget_model.dart
+++ b/lib/features/budgets/models/budget_model.dart
@@ -14,6 +14,8 @@ class Budget {
   final double remainingAmount; // Cuánto queda
   final double lastMonthSpent; // Gastado en el mes anterior
   final double lastMonthAmount; // Presupuesto del mes anterior
+  final double rolloverAmount; // Diferencia del mes anterior
+  final double availableAmount; // Presupuesto base + rollover
 
   Budget({
     required this.id,
@@ -27,6 +29,8 @@ class Budget {
     this.remainingAmount = 0.0,
     this.lastMonthSpent = 0.0,
     this.lastMonthAmount = 0.0,
+    this.rolloverAmount = 0.0,
+    this.availableAmount = 0.0,
   });
 }
 
@@ -36,6 +40,8 @@ class BudgetSummary {
   final double availableToBudget; // Lo que realmente queda para presupuestar
   final String userPlan; // 'free' o 'pro'
   final bool enableBudgetRollover;
+  final double totalBaseBudget; // Suma de presupuestos del mes
+  final double totalAvailableBudget; // Suma con rollover aplicado
 
   BudgetSummary({
     this.spendingBalance = 0.0,
@@ -43,5 +49,7 @@ class BudgetSummary {
     this.availableToBudget = 0.0,
     required this.userPlan,
     required this.enableBudgetRollover,
+    this.totalBaseBudget = 0.0,
+    this.totalAvailableBudget = 0.0,
   });
 }

--- a/lib/features/budgets/widgets/budget_card.dart
+++ b/lib/features/budgets/widgets/budget_card.dart
@@ -77,9 +77,14 @@ class BudgetCard extends StatelessWidget {
                 mainAxisAlignment: MainAxisAlignment.spaceBetween,
                 children: [
                   Text('Gastado: ${formatter.format(budget.spentAmount)}'),
-                  Text('Límite: ${formatter.format(budget.amount)}',
+                  Text('Disponible: ${formatter.format(budget.availableAmount)}',
                       style: const TextStyle(fontWeight: FontWeight.bold)),
                 ],
+              ),
+              const SizedBox(height: 4),
+              Text(
+                'Base: ${formatter.format(budget.amount)} | Rollover: ${formatter.format(budget.rolloverAmount)}',
+                style: Theme.of(context).textTheme.bodySmall,
               ),
               const SizedBox(height: 4),
               Text(

--- a/lib/features/budgets/widgets/budget_summary_header.dart
+++ b/lib/features/budgets/widgets/budget_summary_header.dart
@@ -51,6 +51,24 @@ class BudgetSummaryHeader extends StatelessWidget {
                 ),
               ],
             ),
+            const SizedBox(height: 12),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                const Text('Presupuesto base:'),
+                Text(formatter.format(summary.totalBaseBudget),
+                    style: const TextStyle(fontWeight: FontWeight.bold)),
+              ],
+            ),
+            const SizedBox(height: 4),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                const Text('Presupuesto disponible:'),
+                Text(formatter.format(summary.totalAvailableBudget),
+                    style: const TextStyle(fontWeight: FontWeight.bold)),
+              ],
+            ),
           ],
         ),
       ),


### PR DESCRIPTION
## Summary
- compute last month's budgets and expenses to support rollover
- merge rollover amounts with current budgets and expose totals
- display available budget including rollover in summary header and budget cards

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6b5df3c408325b6ff99ae1bb52020