### PR TITLE
Move floating action buttons to top-right on all main screens

### DIFF
--- a/lib/features/accounts/screens/accounts_screen.dart
+++ b/lib/features/accounts/screens/accounts_screen.dart
@@ -89,6 +89,7 @@ class _AccountsScreenState extends State<AccountsScreen> {
         child: const Icon(Icons.add, color: Colors.white),
         shape: const CircleBorder(),
       ),
+      floatingActionButtonLocation: FloatingActionButtonLocation.endTop,
       body: FutureBuilder<AccountSummary>(
         future: _accountSummaryFuture,
         builder: (context, snapshot) {

--- a/lib/features/budgets/screens/budget_screen.dart
+++ b/lib/features/budgets/screens/budget_screen.dart
@@ -147,6 +147,7 @@ class _BudgetScreenState extends State<BudgetScreen> {
         onPressed: () => _openBudgetDialog(),
         child: const Icon(Icons.add),
       ),
+      floatingActionButtonLocation: FloatingActionButtonLocation.endTop,
       body: FutureBuilder<Map<String, dynamic>>(
         future: _dataFuture,
         builder: (context, snapshot) {

--- a/lib/features/fixed_expenses/screens/fixed_expenses_screen.dart
+++ b/lib/features/fixed_expenses/screens/fixed_expenses_screen.dart
@@ -87,6 +87,7 @@ class _FixedExpensesScreenState extends State<FixedExpensesScreen> {
         },
         child: const Icon(Icons.add),
       ),
+      floatingActionButtonLocation: FloatingActionButtonLocation.endTop,
       body: FutureBuilder<List<FixedExpense>>(
         future: _fixedExpensesFuture,
         builder: (context, snapshot) {

--- a/lib/features/goals/screens/goals_screen.dart
+++ b/lib/features/goals/screens/goals_screen.dart
@@ -118,6 +118,7 @@ class _GoalsScreenState extends State<GoalsScreen> {
         onPressed: () => _navigateAndRefresh(),
         child: const Icon(Icons.add),
       ),
+      floatingActionButtonLocation: FloatingActionButtonLocation.endTop,
       body: FutureBuilder<Map<String, dynamic>>(
         future: _dataFuture,
         builder: (context, snapshot) {

--- a/lib/features/investments/screens/investments_screen.dart
+++ b/lib/features/investments/screens/investments_screen.dart
@@ -70,6 +70,7 @@ class _InvestmentsScreenState extends State<InvestmentsScreen> {
         onPressed: () => _navigateAndRefresh(),
         child: const Icon(Icons.add),
       ),
+      floatingActionButtonLocation: FloatingActionButtonLocation.endTop,
       body: FutureBuilder<List<Investment>>(
         future: _investmentsFuture,
         builder: (context, snapshot) {

--- a/lib/features/transactions/screens/transactions_screen.dart
+++ b/lib/features/transactions/screens/transactions_screen.dart
@@ -72,6 +72,7 @@ class _TransactionsScreenState extends State<TransactionsScreen> {
         child: const Icon(Icons.add),
         backgroundColor: Theme.of(context).colorScheme.primary,
       ),
+      floatingActionButtonLocation: FloatingActionButtonLocation.endTop,
       body: SafeArea(
         child: Padding(
           padding: const EdgeInsets.symmetric(horizontal: 16.0),


### PR DESCRIPTION
## Summary
- Place all primary FABs at the top-right corner of their screens
- Adds `floatingActionButtonLocation: FloatingActionButtonLocation.endTop` to fixed expenses, transactions, goals, budgets, accounts, and investments screens

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7fb527c0c83259769777e8f369150