### PR TITLE
Move add fixed expense button to AppBar

### DIFF
--- a/lib/features/fixed_expenses/screens/fixed_expenses_screen.dart
+++ b/lib/features/fixed_expenses/screens/fixed_expenses_screen.dart
@@ -76,18 +76,17 @@ class _FixedExpensesScreenState extends State<FixedExpensesScreen> {
             icon: Icon(_isListView ? Icons.calendar_month_outlined : Icons.list_alt_outlined),
             onPressed: () => setState(() => _isListView = !_isListView),
           ),
+          IconButton(
+            icon: const Icon(Icons.add),
+            onPressed: () async {
+              final result = await Navigator.of(context).push<bool>(
+                MaterialPageRoute(builder: (context) => const AddEditFixedExpenseScreen()),
+              );
+              if (result == true) _loadData();
+            },
+          ),
         ],
       ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: () async {
-          final result = await Navigator.of(context).push<bool>(
-            MaterialPageRoute(builder: (context) => const AddEditFixedExpenseScreen()),
-          );
-          if (result == true) _loadData();
-        },
-        child: const Icon(Icons.add),
-      ),
-      floatingActionButtonLocation: FloatingActionButtonLocation.endTop,
       body: FutureBuilder<List<FixedExpense>>(
         future: _fixedExpensesFuture,
         builder: (context, snapshot) {


### PR DESCRIPTION
## Summary
- remove floating action button from fixed expenses screen
- add "add" icon button to AppBar that opens AddEditFixedExpenseScreen and refreshes data

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b8017f26f08325902eebdc77db6db3