### PR TITLE
Mueve botón de agregar presupuesto a la AppBar

### DIFF
--- a/lib/features/budgets/screens/budget_screen.dart
+++ b/lib/features/budgets/screens/budget_screen.dart
@@ -141,13 +141,12 @@ class _BudgetScreenState extends State<BudgetScreen> {
               ),
             ],
           ),
+          IconButton(
+            icon: const Icon(Icons.add),
+            onPressed: () => _openBudgetDialog(),
+          ),
         ],
       ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: () => _openBudgetDialog(),
-        child: const Icon(Icons.add),
-      ),
-      floatingActionButtonLocation: FloatingActionButtonLocation.endTop,
       body: FutureBuilder<Map<String, dynamic>>(
         future: _dataFuture,
         builder: (context, snapshot) {


### PR DESCRIPTION
## Summary
- Eliminar `floatingActionButton` del `BudgetScreen` y su ubicación
- Añadir botón de agregar en la `AppBar` junto al menú de opciones

## Testing
- `flutter analyze` *(falla: command not found)*
- `flutter test` *(falla: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b80199014083258cf5dd7e2ee2ce96