### PR TITLE
feat: keep selected budget after tap

### DIFF
--- a/lib/features/budgets/widgets/budget_distribution_chart.dart
+++ b/lib/features/budgets/widgets/budget_distribution_chart.dart
@@ -36,13 +36,16 @@ class BudgetDistributionChartState extends State<BudgetDistributionChart> {
                     pieTouchData: PieTouchData(
                       touchCallback: (FlTouchEvent event, pieTouchResponse) {
                         setState(() {
-                          if (!event.isInterestedForInteractions ||
-                              pieTouchResponse == null ||
-                              pieTouchResponse.touchedSection == null) {
+                          final touchedSection = pieTouchResponse?.touchedSection;
+                          if (touchedSection == null) {
                             touchedIndex = -1;
                             return;
                           }
-                          touchedIndex = pieTouchResponse.touchedSection!.touchedSectionIndex;
+
+                          if (event is FlTapUpEvent) {
+                            touchedIndex =
+                                touchedSection.touchedSectionIndex;
+                          }
                         });
                       },
                     ),


### PR DESCRIPTION
## Summary
- maintain pie chart selection until a new section or outside tap

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b96524c9a883258245b7c669d1234b