### PR TITLE
feat: redirect to login when session missing

### DIFF
--- a/lib/features/profile/screens/change_password_screen.dart
+++ b/lib/features/profile/screens/change_password_screen.dart
@@ -25,6 +25,20 @@ class _ChangePasswordScreenState extends State<ChangePasswordScreen> {
   
   /// Función para manejar la actualización de la contraseña
   Future<void> _updatePassword() async {
+    // Verificamos que exista una sesión activa
+    if (Supabase.instance.client.auth.currentSession == null) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: const Text('Sesión expirada. Inicia sesión nuevamente.'),
+            backgroundColor: Theme.of(context).colorScheme.error,
+          ),
+        );
+        Navigator.of(context).pushReplacementNamed('/login');
+      }
+      return;
+    }
+
     // Primero, validamos el formulario
     if (!_formKey.currentState!.validate()) {
       return;


### PR DESCRIPTION
## Summary
- show error and redirect to login if Supabase session is null during password update

## Testing
- ⚠️ `flutter test` (command not found, flutter unavailable despite installation attempt)


------
https://chatgpt.com/codex/tasks/task_e_68b97f4138d88325b7b3e252c653d786