### PR TITLE
feat: add theme selection bottom sheet

### DIFF
--- a/lib/features/settings/screens/settings_screen.dart
+++ b/lib/features/settings/screens/settings_screen.dart
@@ -79,7 +79,54 @@ class _SettingsScreenState extends State<SettingsScreen> {
               SettingsCard(
                 title: 'Apariencia',
                 children: [
-                  SettingsNavigationRow(label: 'Tema de la Aplicación', icon: Icons.palette_outlined, onTap: () {}),
+                  SettingsNavigationRow(
+                    label: 'Tema de la Aplicación',
+                    icon: Icons.palette_outlined,
+                    onTap: () {
+                      showModalBottomSheet(
+                        context: context,
+                        builder: (context) {
+                          return SafeArea(
+                            child: Column(
+                              mainAxisSize: MainAxisSize.min,
+                              children: [
+                                ListTile(
+                                  title: const Text('Predeterminado del sistema'),
+                                  trailing: profile.theme == 'system'
+                                      ? const Icon(Icons.check)
+                                      : null,
+                                  onTap: () {
+                                    Navigator.pop(context);
+                                    _updateSetting('theme', 'system');
+                                  },
+                                ),
+                                ListTile(
+                                  title: const Text('Claro'),
+                                  trailing: profile.theme == 'light'
+                                      ? const Icon(Icons.check)
+                                      : null,
+                                  onTap: () {
+                                    Navigator.pop(context);
+                                    _updateSetting('theme', 'light');
+                                  },
+                                ),
+                                ListTile(
+                                  title: const Text('Oscuro'),
+                                  trailing: profile.theme == 'dark'
+                                      ? const Icon(Icons.check)
+                                      : null,
+                                  onTap: () {
+                                    Navigator.pop(context);
+                                    _updateSetting('theme', 'dark');
+                                  },
+                                ),
+                              ],
+                            ),
+                          );
+                        },
+                      );
+                    },
+                  ),
                   SettingsNavigationRow(label: 'Idioma', icon: Icons.language, onTap: () {}),
                 ],
               ),


### PR DESCRIPTION
## Summary
- add theme selection bottom sheet in settings

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b986aa297c8325a6faabc65ddd7d0d