### PR TITLE
feat(settings): add import data action

### DIFF
--- a/lib/features/settings/screens/settings_screen.dart
+++ b/lib/features/settings/screens/settings_screen.dart
@@ -244,6 +244,17 @@ class _SettingsScreenState extends State<SettingsScreen> {
                 title: 'Datos de la Cuenta',
                 children: [
                   SettingsActionRow(
+                    label: 'Importar mis Datos',
+                    icon: Icons.upload_outlined,
+                    onTap: () {
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        const SnackBar(
+                          content: Text('Funcionalidad no disponible.'),
+                        ),
+                      );
+                    },
+                  ),
+                  SettingsActionRow(
                     label: 'Exportar mis Datos',
                     icon: Icons.download_outlined,
                     onTap: _exportData,


### PR DESCRIPTION
## Summary
- add "Importar mis Datos" action row under "Datos de la Cuenta" that displays not available snackbar

## Testing
- `flutter test` *(command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68b98ab874f88325ab9fdb28565e2e24