### PR TITLE
Optimistic settings updates with rollback on failure

### DIFF
--- a/lib/features/settings/models/profile_model.dart
+++ b/lib/features/settings/models/profile_model.dart
@@ -42,4 +42,32 @@ class Profile {
       planType: map['plan_type'] ?? 'free',
     );
   }
+
+  Profile copyWith({
+    String? id,
+    String? fullName,
+    String? avatarUrl,
+    bool? dobleFactorEnabled,
+    String? theme,
+    String? language,
+    bool? notifyFixedExpense,
+    bool? notifyBudgetAlert,
+    bool? notifyGoalReached,
+    bool? enableBudgetRollover,
+    String? planType,
+  }) {
+    return Profile(
+      id: id ?? this.id,
+      fullName: fullName ?? this.fullName,
+      avatarUrl: avatarUrl ?? this.avatarUrl,
+      dobleFactorEnabled: dobleFactorEnabled ?? this.dobleFactorEnabled,
+      theme: theme ?? this.theme,
+      language: language ?? this.language,
+      notifyFixedExpense: notifyFixedExpense ?? this.notifyFixedExpense,
+      notifyBudgetAlert: notifyBudgetAlert ?? this.notifyBudgetAlert,
+      notifyGoalReached: notifyGoalReached ?? this.notifyGoalReached,
+      enableBudgetRollover: enableBudgetRollover ?? this.enableBudgetRollover,
+      planType: planType ?? this.planType,
+    );
+  }
 }

--- a/lib/features/settings/screens/settings_screen.dart
+++ b/lib/features/settings/screens/settings_screen.dart
@@ -33,11 +33,46 @@ class _SettingsScreenState extends State<SettingsScreen> {
   }
 
   Future<void> _updateSetting(String key, dynamic value) async {
+    final previousProfile = await _profileFuture;
+
+    Profile updatedProfile = previousProfile;
+    switch (key) {
+      case 'theme':
+        updatedProfile = previousProfile.copyWith(theme: value as String);
+        break;
+      case 'language':
+        updatedProfile = previousProfile.copyWith(language: value as String);
+        break;
+      case 'notify_budget_alert':
+        updatedProfile = previousProfile.copyWith(notifyBudgetAlert: value as bool);
+        break;
+      case 'notify_fixed_expense':
+        updatedProfile = previousProfile.copyWith(notifyFixedExpense: value as bool);
+        break;
+      case 'notify_goal_reached':
+        updatedProfile = previousProfile.copyWith(notifyGoalReached: value as bool);
+        break;
+    }
+
+    setState(() {
+      _profileFuture = Future.value(updatedProfile);
+    });
+
     try {
       await _service.updateProfileSetting(key, value);
       _loadProfile();
     } catch (e) {
-      // Manejar error si es necesario
+      setState(() {
+        _profileFuture = Future.value(previousProfile);
+      });
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('Error al actualizar configuración: $e'),
+            backgroundColor: Colors.red,
+          ),
+        );
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- Optimistically update settings state locally before calling backend service.
- Added Profile.copyWith helper for easier state modifications.
- Revert local change and show error SnackBar if service call fails.

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get install -y flutter` *(fails: Unable to locate package)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b98d87a42483258099a7b4726886ad