### PR TITLE
feat: add fixed expense row widget

### DIFF
--- a/lib/features/fixed_expenses/screens/fixed_expenses_screen.dart
+++ b/lib/features/fixed_expenses/screens/fixed_expenses_screen.dart
@@ -7,6 +7,7 @@ import 'package:finai_flutter/features/fixed_expenses/models/fixed_expense_model
 import 'package:finai_flutter/features/fixed_expenses/services/fixed_expenses_service.dart';
 import 'add_edit_fixed_expense_screen.dart';
 import '../widgets/expense_day_details_dialog.dart';
+import '../widgets/fixed_expense_row.dart';
 
 class FixedExpensesScreen extends StatefulWidget {
   const FixedExpensesScreen({super.key});
@@ -130,11 +131,7 @@ class _FixedExpensesScreenState extends State<FixedExpensesScreen> {
                         itemCount: expenses.length,
                         itemBuilder: (context, index) {
                           final expense = expenses[index];
-                          return ListTile(
-                            title: Text(expense.description),
-                            subtitle: Text('Vence: ${DateFormat.yMMMd('es_ES').format(expense.nextDueDate)}'),
-                            trailing: Text('${expense.amount.toStringAsFixed(2)} €'),
-                          );
+                          return FixedExpenseRow(expense: expense);
                         },
                       )
                     : TableCalendar<FixedExpense>(

--- a/lib/features/fixed_expenses/widgets/fixed_expense_row.dart
+++ b/lib/features/fixed_expenses/widgets/fixed_expense_row.dart
@@ -1,0 +1,86 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:finai_flutter/features/fixed_expenses/models/fixed_expense_model.dart';
+import 'package:finai_flutter/features/fixed_expenses/services/fixed_expenses_service.dart';
+
+class FixedExpenseRow extends StatefulWidget {
+  final FixedExpense expense;
+  const FixedExpenseRow({super.key, required this.expense});
+
+  @override
+  State<FixedExpenseRow> createState() => _FixedExpenseRowState();
+}
+
+class _FixedExpenseRowState extends State<FixedExpenseRow> {
+  final _service = FixedExpensesService();
+  late bool _isActive;
+  late bool _notificationEnabled;
+
+  @override
+  void initState() {
+    super.initState();
+    _isActive = widget.expense.isActive;
+    _notificationEnabled = widget.expense.notificationEnabled;
+  }
+
+  Future<void> _toggle(String field, bool value) async {
+    setState(() {
+      if (field == 'is_active') {
+        _isActive = value;
+      } else {
+        _notificationEnabled = value;
+      }
+    });
+    await _service.updateToggle(widget.expense.id, field, value);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final now = DateTime.now();
+    String status;
+    Color statusColor;
+    if (widget.expense.lastPaymentProcessedOn != null &&
+        widget.expense.lastPaymentProcessedOn!.year == now.year &&
+        widget.expense.lastPaymentProcessedOn!.month == now.month) {
+      status = 'Pagado';
+      statusColor = Colors.green;
+    } else if (widget.expense.nextDueDate.isBefore(now)) {
+      status = 'Vencido';
+      statusColor = Colors.red;
+    } else {
+      status = 'Pendiente';
+      statusColor = Colors.orange;
+    }
+
+    return ListTile(
+      title: Text(widget.expense.description),
+      subtitle: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text('Vence: ${DateFormat.yMMMd('es_ES').format(widget.expense.nextDueDate)}'),
+          Text(status, style: TextStyle(color: statusColor)),
+        ],
+      ),
+      trailing: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text('${widget.expense.amount.toStringAsFixed(2)} €'),
+          Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Switch(
+                value: _isActive,
+                onChanged: (value) => _toggle('is_active', value),
+              ),
+              Switch(
+                value: _notificationEnabled,
+                onChanged: (value) => _toggle('notification_enabled', value),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+


### PR DESCRIPTION
## Summary
- add FixedExpenseRow with status calculation and switches
- show fixed expense rows in FixedExpensesScreen

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba141ea0488325829aa7ca422eda3a