### PR TITLE
feat: enable editing and deletion of fixed expenses

### DIFF
--- a/lib/features/fixed_expenses/screens/fixed_expenses_screen.dart
+++ b/lib/features/fixed_expenses/screens/fixed_expenses_screen.dart
@@ -131,7 +131,7 @@ class _FixedExpensesScreenState extends State<FixedExpensesScreen> {
                         itemCount: expenses.length,
                         itemBuilder: (context, index) {
                           final expense = expenses[index];
-                          return FixedExpenseRow(expense: expense);
+                          return FixedExpenseRow(expense: expense, onUpdated: _loadData);
                         },
                       )
                     : TableCalendar<FixedExpense>(

--- a/lib/features/fixed_expenses/widgets/fixed_expense_row.dart
+++ b/lib/features/fixed_expenses/widgets/fixed_expense_row.dart
@@ -2,10 +2,12 @@ import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:finai_flutter/features/fixed_expenses/models/fixed_expense_model.dart';
 import 'package:finai_flutter/features/fixed_expenses/services/fixed_expenses_service.dart';
+import '../screens/add_edit_fixed_expense_screen.dart';
 
 class FixedExpenseRow extends StatefulWidget {
   final FixedExpense expense;
-  const FixedExpenseRow({super.key, required this.expense});
+  final VoidCallback? onUpdated;
+  const FixedExpenseRow({super.key, required this.expense, this.onUpdated});
 
   @override
   State<FixedExpenseRow> createState() => _FixedExpenseRowState();
@@ -32,6 +34,17 @@ class _FixedExpenseRowState extends State<FixedExpenseRow> {
       }
     });
     await _service.updateToggle(widget.expense.id, field, value);
+  }
+
+  Future<void> _edit() async {
+    final result = await Navigator.of(context).push<bool>(
+      MaterialPageRoute(
+        builder: (context) => AddEditFixedExpenseScreen(expense: widget.expense),
+      ),
+    );
+    if (result == true) {
+      widget.onUpdated?.call();
+    }
   }
 
   @override
@@ -68,6 +81,10 @@ class _FixedExpenseRowState extends State<FixedExpenseRow> {
           Row(
             mainAxisSize: MainAxisSize.min,
             children: [
+              IconButton(
+                icon: const Icon(Icons.edit),
+                onPressed: _edit,
+              ),
               Switch(
                 value: _isActive,
                 onChanged: (value) => _toggle('is_active', value),


### PR DESCRIPTION
## Summary
- allow AddEditFixedExpenseScreen to edit existing entries and delete them
- add edit button on each FixedExpenseRow and refresh list after changes

## Testing
- `flutter test` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba7763b6708325bde103f2353797ce