### PR TITLE
Add payment status and legend for fixed expenses

### DIFF
--- a/lib/features/fixed_expenses/models/fixed_expense_model.dart
+++ b/lib/features/fixed_expenses/models/fixed_expense_model.dart
@@ -1,5 +1,7 @@
 // lib/features/fixed_expenses/models/fixed_expense_model.dart
 
+enum PaymentStatus { pagado, pendiente, vencido }
+
 class FixedExpense {
   final String id;
   final String description;
@@ -43,5 +45,17 @@ class FixedExpense {
           ? DateTime.parse(map['last_payment_processed_on'])
           : null,
     );
+  }
+
+  PaymentStatus getStatus(DateTime now) {
+    if (lastPaymentProcessedOn != null &&
+        lastPaymentProcessedOn!.year == now.year &&
+        lastPaymentProcessedOn!.month == now.month) {
+      return PaymentStatus.pagado;
+    } else if (nextDueDate.isBefore(now)) {
+      return PaymentStatus.vencido;
+    } else {
+      return PaymentStatus.pendiente;
+    }
   }
 }

--- a/lib/features/fixed_expenses/screens/fixed_expenses_screen.dart
+++ b/lib/features/fixed_expenses/screens/fixed_expenses_screen.dart
@@ -125,6 +125,18 @@ class _FixedExpensesScreenState extends State<FixedExpensesScreen> {
                   ),
                 ),
               ),
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 16.0),
+                child: Row(
+                  children: const [
+                    _StatusLegend(color: Colors.green, label: 'Pagado'),
+                    SizedBox(width: 8),
+                    _StatusLegend(color: Colors.orange, label: 'Pendiente'),
+                    SizedBox(width: 8),
+                    _StatusLegend(color: Colors.red, label: 'Vencido'),
+                  ],
+                ),
+              ),
               Expanded(
                 child: _isListView
                     ? ListView.builder(
@@ -182,6 +194,27 @@ class _FixedExpensesScreenState extends State<FixedExpensesScreen> {
           );
         },
       ),
+    );
+  }
+}
+
+class _StatusLegend extends StatelessWidget {
+  final Color color;
+  final String label;
+  const _StatusLegend({required this.color, required this.label});
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        Container(
+          width: 12,
+          height: 12,
+          decoration: BoxDecoration(color: color, shape: BoxShape.circle),
+        ),
+        const SizedBox(width: 4),
+        Text(label),
+      ],
     );
   }
 }

--- a/lib/features/fixed_expenses/widgets/fixed_expense_row.dart
+++ b/lib/features/fixed_expenses/widgets/fixed_expense_row.dart
@@ -61,19 +61,22 @@ class _FixedExpenseRowState extends State<FixedExpenseRow> {
   @override
   Widget build(BuildContext context) {
     final now = DateTime.now();
-    String status;
+    final status = widget.expense.getStatus(now);
+    String statusLabel;
     Color statusColor;
-    if (widget.expense.lastPaymentProcessedOn != null &&
-        widget.expense.lastPaymentProcessedOn!.year == now.year &&
-        widget.expense.lastPaymentProcessedOn!.month == now.month) {
-      status = 'Pagado';
-      statusColor = Colors.green;
-    } else if (widget.expense.nextDueDate.isBefore(now)) {
-      status = 'Vencido';
-      statusColor = Colors.red;
-    } else {
-      status = 'Pendiente';
-      statusColor = Colors.orange;
+    switch (status) {
+      case PaymentStatus.pagado:
+        statusLabel = 'Pagado';
+        statusColor = Colors.green;
+        break;
+      case PaymentStatus.pendiente:
+        statusLabel = 'Pendiente';
+        statusColor = Colors.orange;
+        break;
+      case PaymentStatus.vencido:
+        statusLabel = 'Vencido';
+        statusColor = Colors.red;
+        break;
     }
 
     return ListTile(
@@ -82,7 +85,7 @@ class _FixedExpenseRowState extends State<FixedExpenseRow> {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           Text('Vence: ${DateFormat.yMMMd('es_ES').format(widget.expense.nextDueDate)}'),
-          Text(status, style: TextStyle(color: statusColor)),
+          Text(statusLabel, style: TextStyle(color: statusColor)),
         ],
       ),
       trailing: Column(


### PR DESCRIPTION
## Summary
- add PaymentStatus enum and getStatus helper in FixedExpense
- use getStatus in FixedExpenseRow to label and color expenses
- show status color legend on fixed expenses screen

## Testing
- `dart format lib/features/fixed_expenses/models/fixed_expense_model.dart lib/features/fixed_expenses/widgets/fixed_expense_row.dart lib/features/fixed_expenses/screens/fixed_expenses_screen.dart` (fails: command not found)
- `flutter analyze` (fails: command not found)
- `flutter test` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68ba7a3f934483258d484c12bab9ca50