### PR TITLE
fix: handle nullable fixed expense id

### DIFF
--- a/lib/features/transactions/screens/add_edit_transaction_screen.dart
+++ b/lib/features/transactions/screens/add_edit_transaction_screen.dart
@@ -103,12 +103,15 @@ class _AddEditTransactionScreenState extends State<AddEditTransactionScreen> {
 
       final expenses = List<Map<String, dynamic>>.from(data);
 
-      if (_selectedFixedExpenseId != null &&
-          !expenses.any((e) => e['id'] == _selectedFixedExpenseId)) {
+      // Guardamos el id en una variable local para permitir la promoción
+      // de nulabilidad y evitar errores de tipo.
+      final fixedExpenseId = _selectedFixedExpenseId;
+      if (fixedExpenseId != null &&
+          !expenses.any((e) => e['id'] == fixedExpenseId)) {
         final inactive = await Supabase.instance.client
             .from('scheduled_fixed_expenses')
             .select('id, description')
-            .eq('id', _selectedFixedExpenseId)
+            .eq('id', fixedExpenseId)
             .maybeSingle();
         if (inactive != null) {
           expenses.add(Map<String, dynamic>.from(inactive));


### PR DESCRIPTION
## Summary
- guard fixed expense ID by storing it in a local final variable to avoid type mismatch

## Testing
- `dart format lib/features/transactions/screens/add_edit_transaction_screen.dart` *(fails: command not found)*
- `flutter format lib/features/transactions/screens/add_edit_transaction_screen.dart` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb0b783bc48325a9afcf57f4eaf1a8