### PR TITLE
Use image background on auth screens

### DIFF
--- a/lib/features/auth/screens/forgot_password_screen.dart
+++ b/lib/features/auth/screens/forgot_password_screen.dart
@@ -85,11 +85,10 @@ class _ForgotPasswordScreenState extends State<ForgotPasswordScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
       body: Container(
-        decoration: const BoxDecoration(
-          gradient: LinearGradient(
-            colors: [Color(0xFF1a237e), Color(0xFF0d1137)],
-            begin: Alignment.topCenter,
-            end: Alignment.bottomCenter,
+        decoration: BoxDecoration(
+          image: const DecorationImage(
+            image: AssetImage('assets/images/Fondo_app.png'),
+            fit: BoxFit.cover,
           ),
         ),
         child: Center(

--- a/lib/features/auth/screens/login_screen.dart
+++ b/lib/features/auth/screens/login_screen.dart
@@ -175,11 +175,10 @@ class _LoginScreenState extends State<LoginScreen> {
       body: Container(
         width: double.infinity,
         height: double.infinity,
-        decoration: const BoxDecoration(
-          gradient: LinearGradient(
-            colors: [Color(0xFF1a237e), Color(0xFF0d1137)],
-            begin: Alignment.topCenter,
-            end: Alignment.bottomCenter,
+        decoration: BoxDecoration(
+          image: const DecorationImage(
+            image: AssetImage('assets/images/Fondo_app.png'),
+            fit: BoxFit.cover,
           ),
         ),
         child: Stack(

--- a/lib/features/auth/screens/register_screen.dart
+++ b/lib/features/auth/screens/register_screen.dart
@@ -93,11 +93,10 @@ class _RegisterScreenState extends State<RegisterScreen> {
     // Reutilizamos el fondo y la tarjeta de la pantalla de login
     return Scaffold(
       body: Container(
-        decoration: const BoxDecoration(
-          gradient: LinearGradient(
-            colors: [Color(0xFF1a237e), Color(0xFF0d1137)],
-            begin: Alignment.topCenter,
-            end: Alignment.bottomCenter,
+        decoration: BoxDecoration(
+          image: const DecorationImage(
+            image: AssetImage('assets/images/Fondo_app.png'),
+            fit: BoxFit.cover,
           ),
         ),
         child: Center(

--- a/lib/features/auth/screens/update_password_screen.dart
+++ b/lib/features/auth/screens/update_password_screen.dart
@@ -84,11 +84,10 @@ class _UpdatePasswordScreenState extends State<UpdatePasswordScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
       body: Container(
-        decoration: const BoxDecoration(
-          gradient: LinearGradient(
-            colors: [Color(0xFF1a237e), Color(0xFF0d1137)],
-            begin: Alignment.topCenter,
-            end: Alignment.bottomCenter,
+        decoration: BoxDecoration(
+          image: const DecorationImage(
+            image: AssetImage('assets/images/Fondo_app.png'),
+            fit: BoxFit.cover,
           ),
         ),
         child: Center(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -77,6 +77,7 @@ flutter:
   assets:
     - .env
     - assets/images/avatar_predeterminado.png
+    - assets/images/Fondo_app.png
   #   - images/a_dot_ham.jpeg
 
   # An image asset can refer to one or more resolution-specific "variants", see


### PR DESCRIPTION
## Summary
- display Fondo_app.png as background for login, register, forgot password, and update password screens
- include Fondo_app.png in project assets

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get install -y flutter` *(fails: Unable to locate package flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68c0463f31388325b5ff61bc93778011