### PR TITLE
Reorganize login form layout

### DIFF
--- a/lib/features/auth/screens/login_screen.dart
+++ b/lib/features/auth/screens/login_screen.dart
@@ -210,15 +210,15 @@ Widget build(BuildContext context) {
                           _buildSignInButton(),
                           const SizedBox(height: 16),
                           _buildForgotPasswordButton(),
-                          const SizedBox(height: 24),
-                          _buildDivider(),
-                          const SizedBox(height: 24),
-                          _buildSocialButtons(),
                         ],
                       ),
                     ),
                   ),
                 ),
+                const SizedBox(height: 24),
+                _buildDivider(),
+                const SizedBox(height: 24),
+                _buildSocialButtons(),
                 const SizedBox(height: 40),
                 _buildSignUpButton(),
               ],
@@ -311,7 +311,7 @@ Widget build(BuildContext context) {
                     ),
                   )
                 : const Text(
-                    'Iniciar Sesión',
+                    'Entrar',
                     style: TextStyle(
                       fontSize: 16,
                       fontWeight: FontWeight.bold,


### PR DESCRIPTION
## Summary
- reorder login form fields and buttons within GlassCard
- move divider and social login buttons outside GlassCard
- label sign-in button as "Entrar"

## Testing
- `dart format lib/features/auth/screens/login_screen.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c0949902708325893fa828ed18f875