### PR TITLE
Replace divider icon with text in login screen

### DIFF
--- a/lib/features/auth/screens/login_screen.dart
+++ b/lib/features/auth/screens/login_screen.dart
@@ -328,7 +328,7 @@ Widget build(BuildContext context) {
         Expanded(child: Divider(color: Colors.white30)),
         Padding(
           padding: EdgeInsets.symmetric(horizontal: 8.0),
-          child: Icon(Icons.circle, color: Colors.white30, size: 8),
+          child: Text('O', style: TextStyle(color: Colors.white30)),
         ),
         Expanded(child: Divider(color: Colors.white30)),
       ],


### PR DESCRIPTION
## Summary
- Replace divider circle icon with text 'O'

## Testing
- `flutter test` *(fails: command not found; flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68c096661820832595725031a4d363e3