### PR TITLE
Simplify social login to single Google option

### DIFF
--- a/lib/features/auth/screens/login_screen.dart
+++ b/lib/features/auth/screens/login_screen.dart
@@ -336,29 +336,17 @@ Widget build(BuildContext context) {
   }
 
   Widget _buildSocialButtons() {
-    return Row(
-      mainAxisAlignment: MainAxisAlignment.center,
-      children: [
-        Expanded(
-          child: OutlinedButton.icon(
-            icon: const FaIcon(FontAwesomeIcons.google, size: 18),
-            label: const Text('Google'),
-            onPressed: _isLoading ? null : _signInWithGoogle,
-            style: _buildOutlinedButtonStyle(),
-          ),
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: _horizontalPadding),
+      child: SizedBox(
+        width: double.infinity,
+        child: OutlinedButton.icon(
+          icon: const FaIcon(FontAwesomeIcons.google, size: 18),
+          label: const Text('Continuar con Google'),
+          onPressed: _isLoading ? null : _signInWithGoogle,
+          style: _buildOutlinedButtonStyle(),
         ),
-        const SizedBox(width: 16),
-        Expanded(
-          child: OutlinedButton.icon(
-            icon: const FaIcon(FontAwesomeIcons.phone, size: 18),
-            label: const Text('Teléfono'),
-            onPressed: () {
-              // TODO: Implementar Phone Sign-In
-            },
-            style: _buildOutlinedButtonStyle(),
-          ),
-        ),
-      ],
+      ),
     );
   }
 


### PR DESCRIPTION
## Summary
- replace social login row with full-width "Continuar con Google" button
- remove phone sign-in placeholder

## Testing
- `flutter test` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c09764c154832592267b3128d3735b