### PR TITLE
refactor: center login content

### DIFF
--- a/lib/features/auth/screens/login_screen.dart
+++ b/lib/features/auth/screens/login_screen.dart
@@ -184,10 +184,11 @@ Widget build(BuildContext context) {
         // 2) Contenido
         Positioned.fill(
           child: SingleChildScrollView(
-            padding: const EdgeInsets.symmetric(horizontal: _horizontalPadding),
-            child: Column(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: [
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: _horizontalPadding),
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
                 const SizedBox(height: 40),
                 _buildHeader(),
                 const SizedBox(height: 40),


### PR DESCRIPTION
## Summary
- center login form vertically by wrapping scroll content in padding instead of using scroll padding

## Testing
- `flutter --version` *(fails: command not found)*
- `apt-get install -y flutter` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68c14245d438832581f9dfb38d2fed5b