### PR TITLE
refactor: remove isotipo from register screen

### DIFF
--- a/lib/features/auth/screens/register_screen.dart
+++ b/lib/features/auth/screens/register_screen.dart
@@ -204,8 +204,6 @@ class _RegisterScreenState extends State<RegisterScreen> {
   Widget _buildHeader() {
     return Column(
       children: [
-        Image.asset('assets/images/Isotipo.png', height: 130),
-        const SizedBox(height: 24),
         RichText(
           textAlign: TextAlign.center,
           text: const TextSpan(


### PR DESCRIPTION
## Summary
- remove isotipo image from register screen header

## Testing
- `flutter --version` *(fails: command not found)*
- `apt-get install -y flutter` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68c171aae61c83258aa00e7184dabef3