### PR TITLE
Remove isotipo from forgot password screen

### DIFF
--- a/lib/features/auth/screens/forgot_password_screen.dart
+++ b/lib/features/auth/screens/forgot_password_screen.dart
@@ -196,19 +196,13 @@ class _ForgotPasswordScreenState extends State<ForgotPasswordScreen> {
   }
 
   Widget _buildHeader() {
-    return Column(
-      children: [
-        Image.asset('assets/images/Isotipo.png', height: 130),
-        const SizedBox(height: 24),
-        const Text(
-          'Recuperar Contraseña',
-          style: TextStyle(
-            fontSize: 28,
-            fontWeight: FontWeight.bold,
-            color: Colors.white,
-          ),
-        ),
-      ],
+    return const Text(
+      'Recuperar Contraseña',
+      style: TextStyle(
+        fontSize: 28,
+        fontWeight: FontWeight.bold,
+        color: Colors.white,
+      ),
     );
   }
 


### PR DESCRIPTION
## Summary
- remove isotipo image from forgot password screen header

## Testing
- `dart format lib/features/auth/screens/forgot_password_screen.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68c193b99bcc8325a4a6bd08867bfe48